### PR TITLE
Added "--daemon" command to docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ services:
     container_name: e-dnevnik
     image: dkorunic/e-dnevnik-bot:latest
     command:
+      - "--daemon"
       - "--database=/ednevnik/.e-dnevnik.db"
       - "--conffile=/ednevnik/.e-dnevnik.toml"
     # Volumes store your data between container upgrades


### PR DESCRIPTION
--daemon command will enable daemon mode (running as a service).  Otherwise, docker will restart with the message "Service is not enabled, doing just a single run".